### PR TITLE
fix: Add Checks For Payload Type And Header Length

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -638,6 +638,8 @@ class VoiceClient(VoiceProtocol):
         nonce = bytearray(24)
         nonce[:4] = data[-4:]
         data = data[:-4]
+        print(bytes(data))
+        print(bytes(header))
 
         return self.strip_header_ext(
             box.decrypt(bytes(data), bytes(header), bytes(nonce))
@@ -761,11 +763,12 @@ class VoiceClient(VoiceProtocol):
         data: :class:`bytes`
             Bytes received by Discord via the UDP connection used for sending and receiving voice data.
         """
-        if 200 <= data[1] <= 204:
-            # RTCP received.
-            # RTCP provides information about the connection
-            # as opposed to actual audio data, so it's not
-            # important at the moment.
+        if data[1] != 0x78:
+            # We Should Ignore Any Payload Types We Do Not Understand
+            # Ref RFC 3550 5.1 payload type
+            # At Some Point We Noted That We Should Ignore Only Types 200 - 204 inclusive.
+            # They Were Marked As RTCP: Provides Information About The Connection
+            # This Was Too Broad Of A Whitelist, It Is Unclear If This Is Too Narrow Of A Whitelist
             return
         if self.paused:
             return

--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -638,8 +638,6 @@ class VoiceClient(VoiceProtocol):
         nonce = bytearray(24)
         nonce[:4] = data[-4:]
         data = data[:-4]
-        print(bytes(data))
-        print(bytes(header))
 
         return self.strip_header_ext(
             box.decrypt(bytes(data), bytes(header), bytes(nonce))


### PR DESCRIPTION
I got the `0x78` from looking at Eris's source code.